### PR TITLE
Extended with Batching

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ fn main() {
             .short("w")
             .long("workers")
             .value_name("N")
-            .default_value("60")
+            .default_value("1")
             .help("Number of worker threads"))
         .get_matches();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,8 +146,10 @@ fn run_dataflow(articles: usize, batch: usize, runtime: u64, workers: usize) {
 
         while start.elapsed() < time::Duration::from_millis(runtime * 1000) {
 
-            session.advance_to(count);
-            session.insert((count % articles, 0));
+            if count % peers == index {
+                session.advance_to(count);
+                session.insert((count % articles, 0));
+            }
 
             if count % batch == 0 {
                 // all workers indicate they have finished with `count`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,14 +84,15 @@ fn main() {
     let narticles = value_t_or_exit!(args, "narticles", usize);
     let batch = value_t_or_exit!(args, "batch", usize);
     let runtime = value_t_or_exit!(args, "runtime", usize);
+    let workers = value_t_or_exit!(args, "workers", usize);
 
-    run_dataflow(narticles, batch, runtime as u64);
+    run_dataflow(narticles, batch, runtime as u64, workers);
 }
 
-fn run_dataflow(articles: usize, batch: usize, runtime: u64) {
+fn run_dataflow(articles: usize, batch: usize, runtime: u64, workers: usize) {
     //let batch: usize = 100;
 
-    timely::execute(timely::Configuration::Process(1), move |worker| {
+    timely::execute(timely::Configuration::Process(workers,), move |worker| {
         let index = worker.index();
         let peers = worker.peers();
 


### PR DESCRIPTION
Hihihihihihihi.

I've added a few things to the example that may make it more exciting to test. 

There are two new parameters:

`-b` indicates an amount of physical batching. The same computation is performed in either case, but setting a large number here will let differential dataflow do a bit more concurrent work. The default is 1,000.

`-w` indicates a number of timely dataflow workers. This should probably be some small number, no more than the number of cores you have.

I also linked up the `-r` argument so that we can spend fewer than sixty seconds.

Example output:

```
Echidnatron% cargo run --release -- -b1000 -r10 -w2
    Finished release [optimized + debuginfo] target(s) in 0.0 secs
     Running `target/release/eintopf -b1000 -r10 -w2`
Loading finished after Duration { secs: 0, nanos: 122132778 }
worker 0: 5024001 in 10.000586984s => 502370.60848414013
Done
Echidnatron%
```