### PR TITLE
Added read channel

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -188,7 +188,6 @@ fn run_dataflow(articles: usize, batch: usize, read_mix: usize, merge: bool, run
             let &vt_time = vt_in.time();
             for aid in 0..articles {
                 // add article
-                // art_in.send(((aid, format!("Article #{}", aid)), art_time, 1));
                 art_in.send(((aid, format!("Article #{}", aid)), art_time, 1));
 
                 // vote once for each article as we don't have a convenient left join; this ensures

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,13 +26,6 @@ macro_rules! dur_to_ns {
     }}
 }
 
-// #[derive(Debug)]
-// enum Batch {
-//     None,
-//     Logical(usize),
-//     Physical(usize),
-// }
-
 fn main() {
     use clap::{Arg, App};
 
@@ -80,17 +73,12 @@ fn main() {
             .short("q")
             .long("quiet")
             .help("No noisy output while running"))
-        // .arg(Arg::with_name("batch_kind")
-        //     .short("b")
-        //     .long("batch_kind")
-        //     .takes_value(true)
-        //     .requires("batch_size")
-        //     .help("Kind of input batching to use [logical|physical]"))
         .arg(Arg::with_name("batch_size")
+            .short("b")
             .long("batch-size")
             .takes_value(true)
             .default_value("1000")
-            .help("Input batch size to use [if --batch_kind is set]."))
+            .help("Input batch size to use."))
         .arg(Arg::with_name("read_mix")
             .long("read-mix")
             .takes_value(true)
@@ -113,17 +101,6 @@ fn main() {
 
     let narticles = value_t_or_exit!(args, "narticles", usize);
     let bsize = value_t_or_exit!(args, "batch_size", usize);
-    // let batch = match args.value_of("batch_kind") {
-    //     None => Batch::None,
-    //     Some(v) => {
-    //         match v {
-    //             "none" => Batch::None,
-    //             "logical" => Batch::Logical(bsize),
-    //             "physical" => Batch::Physical(bsize),
-    //             _ => panic!("unexpected batch kind {}", v),
-    //         }
-    //     }
-    // };
     let reads = value_t_or_exit!(args, "read_mix", usize);
     let merge = args.is_present("merge_ops");
     let runtime = value_t_or_exit!(args, "runtime", u64);


### PR DESCRIPTION
This PR adds a read input, whose role in life is to accept article identifiers to "read", and return the compound `(article_id, title, count)` triple. This happens after the join maintaining the triples as the article descriptions and vote counts change, and informally corresponds to "looking up" something in a materialized view.

I removed the `batch-kind` parameter for the moment; adding in the reads with writes made it all rather confusing, and I think for this workload there should be limited difference between physical and logical batching.

There is a new `--read-mix` parameter which takes an integer and causes the computation to insert that many reads for each write. A 95:5 read-write mix would have `--read-mix 19` for example.

```
Echidnatron% cargo run --release -- -r10 --read-mix 19 --batch-size 1000 -w2
    Finished release [optimized + debuginfo] target(s) in 0.0 secs
     Running `target/release/eintopf -r10 --read-mix 19 --batch-size 1000 -w2`
Batching: 1000, merging: false
Loading finished after Duration { secs: 0, nanos: 84972514 }
processed 18892001 events in 10.000366947s => 1889130.7666339076
Done
Echidnatron%
```

The implementation is pretty brain-dead. Where we used to probe the output of `awvc` (articles w/vote counts), we now semijoin it with read requests, which should reveal and retract results as we adjust the `reads` collection.

```rust
let probe = awvc.semijoin_u(&reads)
                .probe();
```

The use of a read input is more like a "pub-sub" computation, where there is a standing query for each article identifier present in the `reads` collection; we are just adding to and then immediately (one round later) removing from this collection.

The numbers should improve a bit (maybe 2x-ish?) with a bespoke implementation of "lookup"; all you really want is a timely dataflow operator that hangs out looking at the indexed trace arrangements, and probes them when asked (with the appropriate timely dataflow patience); we don't need all the guff that differential is doing about maintaining and compacting the "I want this article, wait no not any more" collection traces. This operator doesn't exist, but maybe it should?